### PR TITLE
Rid of page globals

### DIFF
--- a/frontend/public/js/etherwallet.js
+++ b/frontend/public/js/etherwallet.js
@@ -676,6 +676,11 @@ const Validator = {
 function onload() {
     currentWallet = null;
     Page.init();
+    Page.setNodes(
+        Nodes.getNodesNames(),
+        Nodes.getCurrentNodeId(),
+        Nodes.canRemoveNode()
+    );
 
     Page.onBalanceWalletValidation = (walletId) => {
         return Validator.walletId(walletId);

--- a/frontend/public/js/etherwallet.js
+++ b/frontend/public/js/etherwallet.js
@@ -844,21 +844,28 @@ function onload() {
         });
     };
 
-    // Page.initTokenPriceChart((err) => {
-    //     if (err) {
-    //         console.log('Init token chart error', err);
-    //     } else {
-    //         Page.$id(Page.ELEMENT_ID.CHART.BUTTONS.WHOLE).click(() => {
-    //             Page.showTokenPriceChart(0);
-    //             return false;
-    //         });
-    //         Page.$id(Page.ELEMENT_ID.CHART.BUTTONS.MONTH).click(() => {
-    //             Page.showTokenPriceChart(+moment().subtract(7, 'day'));
-    //             return false;
-    //         });
-    //         Page.showTokenPriceChart(0);
-    //     }
-    // });
+    // const chartCtx = Page.getChartCanvasElement();
+    // if (chartCtx) {
+    //     console.log('No chart canvas element');
+    // } else {
+    //     Ether.getPriceHistoryData(
+    //         web3,
+    //         CONTRACT.ABI,
+    //         CONTRACT.ID,
+    //         (err, res) => {
+    //             if (!err) {
+    //                 TokenPriceChart.createChart(chartCtx, res);
+    //                 Page.onChartShowWhole = () => {
+    //                     TokenPriceChart.show(0);
+    //                 };
+    //                 Page.onChartShowMonth = () => {
+    //                     TokenPriceChart.show(+moment().subtract(7, 'day'));
+    //                 };
+    //                 TokenPriceChart.show(0);
+    //             }
+    //         }
+    //     );
+    // }
 }
 
 $(onload);

--- a/frontend/public/js/etherwallet.js
+++ b/frontend/public/js/etherwallet.js
@@ -779,7 +779,8 @@ function onload() {
             web3.setProvider(new web3.providers.HttpProvider(url));
             return {
                 id: newNodeId,
-                node: newNode
+                node: newNode,
+                canRemoveNode: Nodes.canRemoveNode()
             };
         } else {
             throw 'Fail to add node';
@@ -789,7 +790,10 @@ function onload() {
     Page.onNodeRemove = (idToRemove) => {
         const {id, node} = Nodes.removeNode(idToRemove);
         web3.setProvider(new web3.providers.HttpProvider(node.url));
-        return id;
+        return {
+            id,
+            canRemoveNode: Nodes.canRemoveNode()
+        };
     };
 
     Page.onNodeChange = (id) => {

--- a/frontend/public/js/page.js
+++ b/frontend/public/js/page.js
@@ -640,11 +640,11 @@ const Page = {
             Page.sellTokensState.toggleValid(countValid, recipientValid);
         }
 
-        Page.$id(Page.ELEMENT_ID.ALTER_WALLET.OPERATIONS.SELL.WALLET).on('input', (evt) => {
+        Page.$id(Page.ELEMENT_ID.ALTER_WALLET.OPERATIONS.SELL.WALLET).on('input', () => {
             showCurrentSellTokensValid();
         });
 
-        Page.$id(Page.ELEMENT_ID.ALTER_WALLET.OPERATIONS.SELL.COUNT).on('input', (evt) => {
+        Page.$id(Page.ELEMENT_ID.ALTER_WALLET.OPERATIONS.SELL.COUNT).on('input', () => {
             showCurrentSellTokensValid();
         });
 

--- a/frontend/public/js/page.js
+++ b/frontend/public/js/page.js
@@ -92,7 +92,7 @@ const Page = {
             Page.appendNode(id, name);
         });
         Page.selectNode(currentId);
-        Page.disableRemoveNode(!canRemove);
+        Page.nodesState.disableRemoveNode(!canRemove);
     },
     appendNode(value, name) {
         Page.$id(Page.ELEMENT_ID.NODES.NODE)
@@ -341,9 +341,29 @@ const Page = {
     showTokenPriceChart(fromDate) {
         TokenPriceChart.show(fromDate);
     },
+    nodesState: {
+        _disableRemove: false,
+        _nodeAdding: false,
+        _showCurrentState() {
+            const disableRemove = Page.nodesState._disableRemove;
+            const nodeAdding = Page.nodesState._nodeAdding;
+            Page.disableRemoveNode(disableRemove || nodeAdding);
+            Page.toggleAddNodeGroup(nodeAdding);
+            Page.disableSelectNode(nodeAdding);
+        },
+        init() {
+            Page.nodesState._showCurrentState();
+        },
+        disableRemoveNode(disable) {
+            Page.nodesState._disableRemove = disable;
+            Page.nodesState._showCurrentState();
+        },
+        toggleNodeAdding(adding) {
+            Page.nodesState._nodeAdding = adding;
+            Page.nodesState._showCurrentState();
+        }
+    },
     init() {
-        Page.toggleAddNodeGroup(false);
-        Page.disableSelectNode(false);
         Page.showNodeError();
         Page.showAddNodeError();
         Page.showBalanceError();
@@ -360,20 +380,17 @@ const Page = {
 
         Page.buyTokensState.init();
         Page.sellTokensState.init();
+        Page.nodesState.init();
 
         Page.$id(Page.ELEMENT_ID.NODES.ADD_NODE_SHOW_BUTTON).click(() => {
-            Page.toggleAddNodeGroup(true);
-            Page.disableRemoveNode(true);
-            Page.disableSelectNode(true);
+            Page.nodesState.toggleNodeAdding(true);
             Page.showNodeError();
             Page.showAddNodeError();
             return false;
         });
 
         Page.$id(Page.ELEMENT_ID.NODES.CANCEL).click(() => {
-            Page.toggleAddNodeGroup(false);
-            Page.disableRemoveNode(!Nodes.canRemoveNode());
-            Page.disableSelectNode(false);
+            Page.nodesState.toggleNodeAdding(false);
             Page.showNodeError();
             return false;
         });
@@ -388,9 +405,8 @@ const Page = {
                 const {id, node} = Page.onNodeAdd({name, url, chainId});
                 Page.appendNode(id, node.name);
                 Page.$id(Page.ELEMENT_ID.NODES.NODE).val(id);
-                Page.toggleAddNodeGroup(false);
-                Page.disableRemoveNode(!Nodes.canRemoveNode());
-                Page.disableSelectNode(false);
+                Page.nodesState.toggleNodeAdding(false);
+                Page.nodesState.disableRemoveNode(!Nodes.canRemoveNode()); // TODO get 'can remove' from onNodeRemove
             }
             catch (e) {
                 Page.showAddNodeError(e);
@@ -408,7 +424,7 @@ const Page = {
             } catch (e) {
                 Page.showNodeError(e);
             }
-            Page.disableRemoveNode(!Nodes.canRemoveNode());
+            Page.nodesState.disableRemoveNode(!Nodes.canRemoveNode()); // TODO get 'can remove' from onNodeRemove
             return false;
         });
 

--- a/frontend/public/js/page.js
+++ b/frontend/public/js/page.js
@@ -310,26 +310,8 @@ const Page = {
     showSellTransaction(id, complete, fail) {
         Page.showTransaction(Page.ELEMENT_ID.ALTER_WALLET.OPERATIONS.SELL, id, complete, fail);
     },
-    initTokenPriceChart(callback) {
-        const ctx = Page.$id(Page.ELEMENT_ID.CHART.ID)[0];
-        if (!ctx) {
-            callback('No canvas element');
-            return;
-        }
-        Ether.getPriceHistoryData(//Ether
-            web3,//web3
-            CONTRACT.ABI,//CONTRACT
-            CONTRACT.ID,
-            (err, res) => {
-                if (!err) {
-                    TokenPriceChart.createChart(ctx, res);//TokenPriceChart
-                }
-                callback(err, res);
-            }
-        );
-    },
-    showTokenPriceChart(fromDate) {
-        TokenPriceChart.show(fromDate);
+    getChartCanvasElement() {
+        return Page.$id(Page.ELEMENT_ID.CHART.ID)[0];
     },
     nodesState: {
         _disableRemove: false,
@@ -561,6 +543,15 @@ const Page = {
             return false;
         });
 
+        Page.$id(Page.ELEMENT_ID.CHART.BUTTONS.WHOLE).click(() => {
+            Page.onChartShowWhole();
+            return false;
+        });
+        Page.$id(Page.ELEMENT_ID.CHART.BUTTONS.MONTH).click(() => {
+            Page.onChartShowMonth();
+            return false;
+        });
+
         // Add node validation >>>
 
         Page.showAddNodeValid(false);
@@ -663,5 +654,7 @@ const Page = {
     onBalanceWalletValidation() {},
     onAlterWalletValidation() {},
     onBuyTokensValidation() {},
-    onSellTokensValidation() {}
+    onSellTokensValidation() {},
+    onChartShowWhole() {},
+    onChartShowMonth() {}
 };

--- a/frontend/public/js/page.js
+++ b/frontend/public/js/page.js
@@ -316,13 +316,13 @@ const Page = {
             callback('No canvas element');
             return;
         }
-        Ether.getPriceHistoryData(
-            web3,
-            CONTRACT.ABI,
+        Ether.getPriceHistoryData(//Ether
+            web3,//web3
+            CONTRACT.ABI,//CONTRACT
             CONTRACT.ID,
             (err, res) => {
                 if (!err) {
-                    TokenPriceChart.createChart(ctx, res);
+                    TokenPriceChart.createChart(ctx, res);//TokenPriceChart
                 }
                 callback(err, res);
             }

--- a/frontend/public/js/page.js
+++ b/frontend/public/js/page.js
@@ -495,7 +495,7 @@ const Page = {
                     });
             }
             catch (e) {
-                Page.showAlterWalletFileError(err);
+                Page.showAlterWalletFileError(e);
             }
             return false;
         });

--- a/frontend/public/js/page.js
+++ b/frontend/public/js/page.js
@@ -393,11 +393,11 @@ const Page = {
                 const name = Page.$id(Page.ELEMENT_ID.NODES.NAME).val();
                 const url = Page.$id(Page.ELEMENT_ID.NODES.URL).val();
                 const chainId = Page.$id(Page.ELEMENT_ID.NODES.CHAIN_ID).val();
-                const {id, node} = Page.onNodeAdd({name, url, chainId});
+                const {id, node, canRemoveNode} = Page.onNodeAdd({name, url, chainId});
                 Page.appendNode(id, node.name);
                 Page.$id(Page.ELEMENT_ID.NODES.NODE).val(id);
                 Page.nodesState.toggleNodeAdding(false);
-                Page.nodesState.disableRemoveNode(!Nodes.canRemoveNode()); // TODO get 'can remove' from onNodeRemove
+                Page.nodesState.disableRemoveNode(!canRemoveNode);
             }
             catch (e) {
                 Page.showAddNodeError(e);
@@ -409,13 +409,13 @@ const Page = {
             Page.showNodeError();
             const curNodeId = Page.$id(Page.ELEMENT_ID.NODES.NODE).val();
             try {
-                const id = Page.onNodeRemove(curNodeId);
+                const {id, canRemoveNode} = Page.onNodeRemove(curNodeId);
                 Page.removeNode(curNodeId);
+                Page.nodesState.disableRemoveNode(!canRemoveNode);
                 Page.$id(Page.ELEMENT_ID.NODES.NODE).val(id);
             } catch (e) {
                 Page.showNodeError(e);
             }
-            Page.nodesState.disableRemoveNode(!Nodes.canRemoveNode()); // TODO get 'can remove' from onNodeRemove
             return false;
         });
 

--- a/frontend/public/js/page.js
+++ b/frontend/public/js/page.js
@@ -87,12 +87,12 @@ const Page = {
     $id(id) {
         return $(`#${id}`);
     },
-    updateNodes() {
-        const nodesNames = Nodes.getNodesNames();
+    setNodes(nodesNames, currentId, canRemove) {
         $.each(nodesNames, (i, {id, name}) => {
             Page.appendNode(id, name);
         });
-        Page.selectNode(Nodes.getCurrentNodeId());
+        Page.selectNode(currentId);
+        Page.disableRemoveNode(!canRemove);
     },
     appendNode(value, name) {
         Page.$id(Page.ELEMENT_ID.NODES.NODE)
@@ -343,7 +343,6 @@ const Page = {
     },
     init() {
         Page.toggleAddNodeGroup(false);
-        Page.disableRemoveNode(!Nodes.canRemoveNode());
         Page.disableSelectNode(false);
         Page.showNodeError();
         Page.showAddNodeError();
@@ -358,7 +357,6 @@ const Page = {
         Page.showSellTokensError();
         Page.showBuyTransaction();
         Page.showSellTransaction();
-        Page.updateNodes();
 
         Page.buyTokensState.init();
         Page.sellTokensState.init();

--- a/frontend/public/js/page.js
+++ b/frontend/public/js/page.js
@@ -53,7 +53,7 @@ const Page = {
             FILE: {
                 GROUP: 'add-wallet-file-group',
                 FILE: 'add-wallet-file',
-                PASWORD: 'add-wallet-file-password',
+                PASSWORD: 'add-wallet-file-password',
                 BUTTON: 'add-wallet-file-button',
                 ERROR: 'add-wallet-file-error'
             },
@@ -127,7 +127,7 @@ const Page = {
     showTokensHistory(walletId, res) {
         Page.$id(Page.ELEMENT_ID.TOKENS_HISTORY.CONTAINER).css('visibility', res == null ? 'hidden' : 'visible');
 
-        const $tmpl = Page.$id(Page.ELEMENT_ID.TOKENS_HISTORY.TEMPLATE);
+        const $template = Page.$id(Page.ELEMENT_ID.TOKENS_HISTORY.TEMPLATE);
 
         function addElementIdKey($el, key) {
             const newId = $el[0].id + '-' + key;
@@ -151,7 +151,7 @@ const Page = {
         }
 
         const $rows = res && res.map((item, index) => {
-            const $el = $tmpl.clone().show();
+            const $el = $template.clone().show();
             addElementIdKey($el, index);
             setElementIdContent($el, Page.ELEMENT_ID.TOKENS_HISTORY.OPERATION.TIME, index, moment(item.timestamp * 1000).format('DD.MM.YY HH:mm:ss'));
             const isBuy = walletId.toLowerCase() === item.to.toLowerCase();
@@ -218,7 +218,7 @@ const Page = {
         Page.$id(Page.ELEMENT_ID.ALTER_WALLET.FILE.GROUP).toggleClass('has-error', !fileValid || !filePasswordValid);
         Page.$id(Page.ELEMENT_ID.ALTER_WALLET.FILE.BUTTON).prop('disabled', !fileValid || !filePasswordValid);
         Page.$id(Page.ELEMENT_ID.ALTER_WALLET.FILE.FILE).toggleClass('alert-danger', !fileValid);
-        Page.$id(Page.ELEMENT_ID.ALTER_WALLET.FILE.PASWORD).toggleClass('alert-danger', !filePasswordValid);
+        Page.$id(Page.ELEMENT_ID.ALTER_WALLET.FILE.PASSWORD).toggleClass('alert-danger', !filePasswordValid);
     },
     showCurrentWallet(wallet) {
         Page.$id(Page.ELEMENT_ID.ALTER_WALLET.OPERATIONS.CONTAINER).toggle(!!wallet);
@@ -484,7 +484,7 @@ const Page = {
             Page.showAlterWalletPrivateKeyError();
             Page.showAlterWalletFileError();
             const file = Page.$id(Page.ELEMENT_ID.ALTER_WALLET.FILE.FILE)[0].files[0];
-            const password = Page.$id(Page.ELEMENT_ID.ALTER_WALLET.FILE.PASWORD).val();
+            const password = Page.$id(Page.ELEMENT_ID.ALTER_WALLET.FILE.PASSWORD).val();
             try {
                 Page.onAlterWalletFileAsync(file, password)
                     .then((wallet) => {

--- a/frontend/public/js/page.js
+++ b/frontend/public/js/page.js
@@ -105,16 +105,6 @@ const Page = {
             .find(`[value="${value}"]`)
             .remove();
     },
-    disableRemoveNode(disable) {
-        Page.$id(Page.ELEMENT_ID.NODES.REMOVE_NODE_BUTTON).prop('disabled', disable);
-    },
-    disableSelectNode(disable) {
-        Page.$id(Page.ELEMENT_ID.NODES.NODE).prop('disabled', disable);
-    },
-    toggleAddNodeGroup(show) {
-        Page.$id(Page.ELEMENT_ID.NODES.ADD_NODE_GROUP).toggle(show);
-        Page.$id(Page.ELEMENT_ID.NODES.ADD_NODE_SHOW_BUTTON).prop('disabled', show);
-    },
     showWalletValid(isValid) {
         Page.$id(Page.ELEMENT_ID.BALANCE.WALLET_FORM_GROUP).toggleClass('has-error', !isValid);
         Page.$id(Page.ELEMENT_ID.BALANCE.CHECK_BUTTON).prop('disabled', !isValid);
@@ -347,9 +337,10 @@ const Page = {
         _showCurrentState() {
             const disableRemove = Page.nodesState._disableRemove;
             const nodeAdding = Page.nodesState._nodeAdding;
-            Page.disableRemoveNode(disableRemove || nodeAdding);
-            Page.toggleAddNodeGroup(nodeAdding);
-            Page.disableSelectNode(nodeAdding);
+            Page.$id(Page.ELEMENT_ID.NODES.REMOVE_NODE_BUTTON).prop('disabled', disableRemove || nodeAdding);
+            Page.$id(Page.ELEMENT_ID.NODES.ADD_NODE_GROUP).toggle(nodeAdding);
+            Page.$id(Page.ELEMENT_ID.NODES.ADD_NODE_SHOW_BUTTON).prop('disabled', nodeAdding);
+            Page.$id(Page.ELEMENT_ID.NODES.NODE).prop('disabled', nodeAdding);
         },
         init() {
             Page.nodesState._showCurrentState();


### PR DESCRIPTION
Не использовать в page.js глобальные объекты из etherwallet.js: ```Nodes```, ```Ether```, ```web3```,
```CONTRACT``` и ```TokenPriceChart```. Мелкие фиксы, обнаруженные при просмотре кода.